### PR TITLE
chore: update device-test-core library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ wordlist.txt
 results/
 .vscode/
 launch.json
+.venv/
 DeviceLibrary/_version.py
 log.html
 report.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["version"]
 dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "unidecode >= 1.3.6, < 2.0.0",
-  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
+  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
 ]
 
 [project.optional-dependencies]
@@ -33,13 +33,13 @@ all = [
     "robotframework-devicelibrary[local]",
 ]
 ssh = [
-    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
+    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
 ]
 local = [
-    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
+    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
 ]
 docker = [
-    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.10.2",
+    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
 ]
 
 test = [


### PR DESCRIPTION
Update to remove a deprecation warning which originates from an older paramiko library version.