### PR TITLE
fix: update device-test-core to fix docker-py issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["version"]
 dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "unidecode >= 1.3.6, < 2.0.0",
-  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
+  "device-test-core @ git+https://github.com/reubenmiller/device-test-core.git@1.11.1",
 ]
 
 [project.optional-dependencies]
@@ -33,13 +33,13 @@ all = [
     "robotframework-devicelibrary[local]",
 ]
 ssh = [
-    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
+    "device-test-core[ssh] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.1",
 ]
 local = [
-    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
+    "device-test-core[local] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.1",
 ]
 docker = [
-    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.0",
+    "device-test-core[docker] @ git+https://github.com/reubenmiller/device-test-core.git@1.11.1",
 ]
 
 test = [


### PR DESCRIPTION
Update dependencies to fix docker-py issue when trying to connect to the docker host when a newer versions of requests is being used.