### PR TITLE
fix(Logs Should Contain): fix max_matches error message reference

### DIFF
--- a/DeviceLibrary/DeviceLibrary.py
+++ b/DeviceLibrary/DeviceLibrary.py
@@ -791,7 +791,7 @@ class DeviceLibrary:
         if max_matches is not None:
             assert len(matches) <= max_matches, (
                 "Total matching log entries is greater than expected. "
-                f"wanted={min_matches} (max)\n"
+                f"wanted={max_matches} (max)\n"
                 f"got={len(matches)}\n\n"
                 f"entries:\n{matches}"
             )


### PR DESCRIPTION
Fixed an incorrect variable reference in the assertion message when the max_matches is exceeded (it previously referenced the min_matches in the assertion text)